### PR TITLE
cleanup: remove unnecessary spacing form the build_deploy script

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -2,7 +2,6 @@
 set -ex
 
 login_container_registry() {
-
     local USER="$1"
     local PASSWORD="$2"
     local REGISTRY="$3"


### PR DESCRIPTION
Mostly just to trigger a build in quay :see_no_evil: 