### PR TITLE
feat: assume cluster settings from the current context by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,18 @@ Simple container providing a kubectl port-forwarding proxy for linking a compose
 
 ## Usage
 
-Attaché has been designed for use with docker-compose (or podman-compose) to link a set of locally running services with a pod running in Kubernetes. Each remote service should have its own attaché counterpart that is responsible for port-forwarding into the composed environment. First of all, on your local machine, you should be authorized against the target Kubernetes cluster, i.e. `kubectl` should work locally and you should have a `kubeconfig file`. The compose entry requires the following environment variables to be set:
+Attaché has been designed for use with docker-compose (or podman-compose) to link a set of locally running services with a pod running in Kubernetes. Each remote service should have its own attaché counterpart that is responsible for port-forwarding into the composed environment. First of all, on your local machine, you should be authorized against the target Kubernetes cluster, i.e. `kubectl` should work locally and you should have a [kubeconfig](https://github.com/kubernetes/kubernetes/blob/release-1.1/docs/user-guide/kubeconfig-file.md) file. This file has to be attached as a volume to the container as `/root/.kube/config`. The compose entry requires the following environment variables to be set:
 
-| Variable  | Description                                         | Example value    |
-|-----------|-----------------------------------------------------|------------------|
-| CLUSTER   | Name of the cluster configured in KUBECONFIG        | foo.bar.baz      |
-| USER      | Name of the logged in user                          | user/foo.bar.baz |
-| NAMESPACE | Namespace in which the target pod is running        | default          |
-| LABELS    | Comma-separated labels that identify the target pod | name=foo,svc=bar |
-| PORTS     | Space-separated list of TCP ports to be forwarded   | 1234:1234 5678   |
-| INSECURE  | TLS certificate is not verified when set            | 1                |
+| Variable   | Description                                         | Example value    |
+|------------|-----------------------------------------------------|------------------|
+| CLUSTER¹   | Name of the cluster configured in KUBECONFIG        | foo.bar.baz      |
+| USER¹      | Name of the logged in user                          | user/foo.bar.baz |
+| NAMESPACE¹ | Namespace in which the target pod is running        | default          |
+| LABELS     | Comma-separated labels that identify the target pod | name=foo,svc=bar |
+| PORTS      | Space-separated list of TCP ports to be forwarded   | 1234:1234 5678   |
+| INSECURE   | TLS certificate is not verified when set            | 1                |
+
+¹ The default value of these variables is assumed from the current context configured in the passed kubeconfig volume.
 
 Example configuration in a compose file linking a database service running in Kubernetes with a locally running application:
 ```yaml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,20 +1,5 @@
 #!/bin/bash
 
-if [[ -z "$CLUSTER" ]]; then
-  echo "Container failed to start, CLUSTER not set"
-  exit 1
-fi
-
-if [[ -z "$USER" ]]; then
-  echo "Container failed to start, USER not set"
-  exit 1
-fi
-
-if [[ -z "$NAMESPACE" ]]; then
-  echo "Container failed to start, NAMESPACE not set"
-  exit 1
-fi
-
 if [[ -z "$LABELS" ]]; then
   echo "Container failed to start, LABELS not set"
   exit 1
@@ -31,7 +16,25 @@ if [[ ! -f "/root/.kube/config" ]]; then
 fi
 
 kube_client() {
-  kubectl "${INSECURE:+'--insecure-skip-tls-verify'}" --cluster "${CLUSTER}" --user "${USER}" --namespace "${NAMESPACE}" "${@}";
+  params=()
+
+  if [[ "$CLUSTER" ]]; then
+    params+=("--cluster=${CLUSTER}")
+  fi
+
+  if [[ "$USER" ]]; then
+    params+=("--user=${USER}")
+  fi
+
+  if [[ "$NAMESPACE" ]]; then
+    params+=("--namespace=${NAMESPACE}")
+  fi
+
+  if [[ "$INSECURE" ]]; then
+    params+=("--insecure-skip-tls-verify")
+  fi
+
+  kubectl "${@}" "${params[@]}";
 }
 
 POD_NAME=$(kube_client get pod -l "${LABELS}" -o name | shuf -n1)


### PR DESCRIPTION
When not setting the environment variables, the service should *Just Work&trade;* with the current context actually set by the kubeconfig.